### PR TITLE
Synchronize call to MarcHandler.init() since system properties are static

### DIFF
--- a/lib/solrmarc/src/org/solrmarc/marc/MarcHandler.java
+++ b/lib/solrmarc/src/org/solrmarc/marc/MarcHandler.java
@@ -56,6 +56,7 @@ public abstract class MarcHandler {
 	
 	public void init(String args[])
 	{
+      sychronized(MarcHandler.class) {
         String configProperties = GetDefaultConfig.getConfigName("config.properties");
 
         List<String> addnlArgList = new ArrayList<String>();
@@ -126,6 +127,7 @@ public abstract class MarcHandler {
         {
             loadIndexer(indexerName, indexerProps); 
         }
+      }  
 	}
 		
     /** 


### PR DESCRIPTION
Writing several indices parallel leads to a race condition when reading and writing to system properties.
